### PR TITLE
chore: remove unshallow in fetching tags

### DIFF
--- a/.github/workflows/CD_github_actions.yml
+++ b/.github/workflows/CD_github_actions.yml
@@ -17,8 +17,9 @@ jobs:
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
 
-      # - name: Prepare repository
-      #   run: git fetch --unshallow --tags
+      - name: Prepare repository
+        run: git fetch --tags
+        # run: git fetch --unshallow --tags
 
       - name: Install
         run: npm install


### PR DESCRIPTION
TEST - need to fetch tags for npx auto shipit command => needs to get latest tag in order to bump.
This run, trying without --unshallow => git fetch --tags